### PR TITLE
Ensure containers with static IP addresses have DNS info

### DIFF
--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -683,6 +683,17 @@ func prepareOrGetContainerInterfaceInfo(
 		return nil, errors.Trace(err)
 	}
 
+	dnsServers, searchDomain, dnsErr := localDNSServers()
+
+	if dnsErr != nil {
+		return nil, errors.Trace(dnsErr)
+	}
+
+	for i, _ := range preparedInfo {
+		preparedInfo[i].DNSServers = dnsServers
+		preparedInfo[i].DNSSearch = searchDomain
+	}
+
 	log.Tracef("PrepareContainerInterfaceInfo returned %#v", preparedInfo)
 	// Most likely there will be only one item in the list, but check
 	// all of them for forward compatibility.


### PR DESCRIPTION
Since the switch to generate unique MAAS hostnames and with it a switch
to use static IP address allocation a container now has an empty
/etc/resolv.conf; its DNS info previously came from the DHCP lease.

This change augments the manually configured interface info by using the
existing code that parses /etc/resolv.conf (on the host) and adds that
to the containers' interface information.

Fixes [LP:#1528217](https://bugs.launchpad.net/juju-core/+bug/1528217)
